### PR TITLE
Add support for specifying the user to run znc as

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ this on to expose the ports configured for each client service.
 Role Variables
 --------------
 
+* znc_system_user
+
+  User to use on the system to run znc.  By default it will be the same user as
+  what Ansible uses to connect to the system.
+
+* znc_system_group
+
+  Group to use on the system to run znc.  By default it will be the same group
+  as what Ansible uses to connect to the system.
+
 * znc_config_dir
 
   Base directory for the personal ZNC configuration files. A separate
@@ -186,6 +196,13 @@ variables passed in as parameters) is always nice for users too:
       roles:
         - znc-on-znc
       vars:
+        # By default we will run znc as the same user/group Ansible uses to
+        # connect to the system.  If you prefer to specify a different
+        # user/group or if Ansible uses the root user you can specify the
+        # user/group to run znc.  To run znc as the user 'znc' and group 'znc'
+        # uncomment the following two lines:
+        #znc_system_user: znc
+        #znc_system_group: znc
         # znc_user and znc_server_passwords can go into a vault-encrypted file.
         znc_user:
           name: dhellmann

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
 # defaults file for multiznc
-znc_config_dir: "{{ansible_env.HOME}}/znc"
+znc_system_user: "{{ansible_env.USER}}"
+znc_system_group: "{{ansible_env.GROUP}}"
+znc_system_user_dir: "~{{znc_system_user}}"
+znc_config_dir: "{{znc_system_user_dir|expanduser}}/znc"
 znc_base_port: 6666
 znc_max_buffer_size: 5000
 znc_auto_clear_chan_buffer: "false"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -9,3 +9,6 @@
 
 - name: znc-hup-instances
   shell: for f in {{znc_config_dir}}/*/znc.pid; do /bin/kill -HUP `cat $f`; done
+  ignore_errors: yes
+  sudo: yes
+  sudo_user: "{{znc_system_user}}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: Ensure not installing znc to root user
+  fail: msg="Trying to install znc to the root user.  znc refuses to run as root. Please set values for znc_system_user and znc_system_group"
+  when: "'{{znc_system_user}}' == 'root'"
+
 - name: Add ZNC PPA repository
   sudo: yes
   apt_repository: repo=ppa:teward/znc state=present
@@ -14,20 +18,35 @@
     - znc-perl
     - znc-python
     - znc-tcl
+    - openssl
     - monit
+
+# Create the ZNC user if needed
+- name: Create znc group
+  group: name={{znc_system_group}}
+  sudo: yes
+- name: Create znc user
+  user: name={{znc_system_user}} group={{znc_system_user}}
+  sudo: yes
 
 - name: "Base config directory"
   file: path={{znc_config_dir}}/base/configs state=directory mode=0755
+  sudo: yes
+  sudo_user: "{{znc_system_user}}"
 
 - name: "Child config directories"
   file: path={{znc_config_dir}}/{{item.name}}/configs state=directory mode=0755
   with_items: znc_clients
+  sudo: yes
+  sudo_user: "{{znc_system_user}}"
 
 # based on https://github.com/willshersystems/ansible-znc/blob/master/tasks/ssl.yml
 - name: "Base SSL certificate"
   command: znc --datadir={{znc_config_dir}}/base --makepem
   args:
     creates: "{{znc_config_dir}}/base/znc.pem"
+  sudo: yes
+  sudo_user: "{{znc_system_user}}"
 
 - name: "Base SSL certificate fingerprint"
   shell: cat {{znc_config_dir}}/base/znc.pem | openssl x509 -fingerprint -sha256 | grep Fingerprint= | cut -f2 -d=
@@ -39,6 +58,8 @@
   args:
     creates: "{{znc_config_dir}}/{{item.name}}/znc.pem"
   with_items: znc_clients
+  sudo: yes
+  sudo_user: "{{znc_system_user}}"
 
 - name: "Base ZNC config file"
   template: src=znc-base.conf
@@ -46,6 +67,8 @@
             mode=0644
   notify:
     - znc-hup-instances
+  sudo: yes
+  sudo_user: "{{znc_system_user}}"
 
 - name: "Child ZNC config files"
   template: src=znc-child.conf
@@ -54,10 +77,12 @@
   with_items: znc_clients
   notify:
     - znc-hup-instances
+  sudo: yes
+  sudo_user: "{{znc_system_user}}"
 
 - name: Make sure monit is running
   service: name=monit state=running enabled=yes
-  sudo: true
+  sudo: yes
 
 - name: "Base monit config"
   sudo: yes
@@ -67,6 +92,7 @@
     - znc-restart-monit
   with_items:
     - name: base
+  sudo: yes
 
 - name: "Child monit configs"
   sudo: yes
@@ -75,6 +101,7 @@
   notify:
     - znc-restart-monit
   with_items: znc_clients
+  sudo: yes
 
 # Use rinetd to bypass firewalls that block regular IRC ports (or
 # arbitrary ports) by connecting *one* client to port 443.

--- a/templates/znc-monit.conf
+++ b/templates/znc-monit.conf
@@ -1,6 +1,5 @@
-check process znc-{{item.name}}
-  matching "znc.*{{item.name}}"
+check process znc-{{item.name}} with pidfile {{znc_config_dir}}/{{item.name}}/znc.pid
   start program = "/usr/bin/znc -d {{znc_config_dir}}/{{item.name}}"
-  as uid {{ansible_env.USER}} and gid {{ansible_env.USER}}
-  stop program = "/usr/bin/killall /usr/bin/znc"
+  as uid {{znc_system_user}} and gid {{znc_system_user}}
+  stop program = "/bin/bash -c 'kill -s SIGTERM `cat {{znc_config_dir}}/{{item.name}}/znc.pid`'"
   if totalmem is greater than 300 MB for 10 cycles then restart


### PR DESCRIPTION
Can now specify the user to run znc as.

Add the openssl package to the list of required packages to install.

Fail if the user that will run znc is root.
