### PR TITLE
Typos, Warning corrections, Debian 9 & 10 support and no znc-dbg when v1.7

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,7 +30,7 @@
   group: name={{znc_system_group}}
   become: yes
 - name: Create znc user
-  user: name={{znc_system_user}} group={{znc_system_user}}
+  user: name={{znc_system_user}} group={{znc_system_group}}
   become: yes
   tags:
     - zncconfig

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Ensure not installing znc to root user
   fail: msg="Trying to install znc to the root user.  znc refuses to run as root. Please set values for znc_system_user and znc_system_group"
-  when: "'{{znc_system_user}}' == 'root'"
+  when: "'znc_system_user' == 'root'"
 
 - name: Add ZNC PPA repository
   become: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -127,7 +127,7 @@
     - monitconfig
     
 - name: Make sure monit is running
-  service: name=monit state=running enabled=yes
+  service: name=monit state=started enabled=yes
   become: yes
   tags:
     - monitconfig

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -106,7 +106,6 @@
     - zncconfig
     
 - name: "Base monit config"
-  become: yes
   template: src=znc-monit.conf
             dest=/etc/monit/conf.d/znc-{{item.name}}.conf
   notify:
@@ -124,7 +123,6 @@
   notify:
     - znc-restart-monit
   with_items: "{{znc_clients}}"
-  become: yes
   tags:
     - monitconfig
     

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,13 +9,13 @@
   apt_repository: repo=ppa:teward/znc state=present
   tags:
     - zncinstall
+  when: ansible_distribution == 'Ubuntu'
     
 - name: Install packages
   apt: name={{item}} state=latest
   become: yes
   with_items:
     - znc
-    - znc-dbg
     - znc-dev
     - znc-perl
     - znc-python
@@ -25,6 +25,17 @@
   tags:
     - zncinstall
     - monitinstall
+
+- name: Install znc-dbg packages
+  apt: name={{item}} state=latest
+  become: yes
+  with_items:
+    - znc-dbg
+  tags:
+    - zncinstall
+    - monitinstall
+  when: ansible_distribution == 'Debian' and ansible_distribution_release == 'stretch'
+
 # Create the ZNC user if needed
 - name: Create znc group
   group: name={{znc_system_group}}
@@ -127,7 +138,7 @@
     - monitconfig
     
 - name: Make sure monit is running
-  service: name=monit state=running enabled=yes
+  service: name=monit state=started enabled=yes
   become: yes
   tags:
     - monitconfig

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,13 +9,13 @@
   apt_repository: repo=ppa:teward/znc state=present
   tags:
     - zncinstall
+  when: ansible_distribution == 'Ubuntu'
     
 - name: Install packages
   apt: name={{item}} state=latest
   become: yes
   with_items:
     - znc
-    - znc-dbg
     - znc-dev
     - znc-perl
     - znc-python
@@ -25,6 +25,17 @@
   tags:
     - zncinstall
     - monitinstall
+
+- name: Install znc-dbg packages
+  apt: name={{item}} state=latest
+  become: yes
+  with_items:
+    - znc-dbg
+  tags:
+    - zncinstall
+    - monitinstall
+  when: ansible_distribution == 'Debian' and ansible_distribution_release == 'stretch'
+
 # Create the ZNC user if needed
 - name: Create znc group
   group: name={{znc_system_group}}

--- a/templates/znc-monit.conf
+++ b/templates/znc-monit.conf
@@ -1,5 +1,5 @@
 check process znc-{{item.name}} with pidfile {{znc_config_dir}}/{{item.name}}/znc.pid
   start program = "/usr/bin/znc -d {{znc_config_dir}}/{{item.name}}"
-  as uid {{znc_system_user}} and gid {{znc_system_user}}
+  as uid {{znc_system_user}} and gid {{znc_system_group}}
   stop program = "/bin/bash -c 'kill -s SIGTERM `cat {{znc_config_dir}}/{{item.name}}/znc.pid`'"
   if totalmem is greater than 300 MB for 10 cycles then restart


### PR DESCRIPTION
Updated a couple of typos / misuse regarding user/group.
Remove some duplicate become tags
Replaced state=running with state=started
Only install PPA if Ubuntu
Only install znc-dbg if Debian 9 (Ubuntu and Debian 10 all > v1.7 so not required)

Tested on Ubuntu 14,16,18, Debian 9 and 10